### PR TITLE
Handle not autoplaying be default

### DIFF
--- a/videojs.autoplay-toggle.js
+++ b/videojs.autoplay-toggle.js
@@ -136,7 +136,7 @@
             + '&nbsp;/&nbsp;'
             + '<span class="autoplay-toggle autoplay-off">Off</span>'
         + '</span>'
-      + '</div>';
+      '</div>';
     player.controlBar.el().appendChild(autoplayBtn);
 
     // retrieve autoplay from storage and highlight the correct toggle option in *all* video players

--- a/videojs.autoplay-toggle.js
+++ b/videojs.autoplay-toggle.js
@@ -171,13 +171,17 @@
 
     var turnOn = !storage.getItem(key);
     // change player behavior based on toggle
-    if (player.autoplay() && !turnOn) {
-      // this could be autoplaying, make sure to stop it and ensure player's autoplay is false
-      player.autoplay(false);
-      player.pause();
-    } else if (player.autoplay() && turnOn) {
-      // we want this to autoplay
-      player.play();
+    if (player.autoplay()) {
+      if (!turnOn) {
+        // this could be autoplaying, make sure to stop it and ensure player's autoplay is false
+        player.autoplay(false);
+        player.pause();
+      }
+    } else {
+      if (turnOn) {
+        // we want this to autoplay
+        player.play();
+      }
     }
 
     // initialize autoplay toggle

--- a/videojs.autoplay-toggle.js
+++ b/videojs.autoplay-toggle.js
@@ -136,7 +136,7 @@
             + '&nbsp;/&nbsp;'
             + '<span class="autoplay-toggle autoplay-off">Off</span>'
         + '</span>'
-      '</div>';
+      + '</div>';
     player.controlBar.el().appendChild(autoplayBtn);
 
     // retrieve autoplay from storage and highlight the correct toggle option in *all* video players


### PR DESCRIPTION
The current code only executes if `player.autoplay()` returns `true`. This code handles that case as well as it returning `false` or `undefined`. This will happen if either the stream isn't ready when the plugin executes (will return `undefined` in the case of a live stream on occasion) or if you don't include the `autoplay` attribute on the video element.
